### PR TITLE
Fix compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,3 @@ generate_messages(DEPENDENCIES
 
 catkin_package(
   CATKIN_DEPENDS message_runtime)
-
-install(DIRECTORY include/range_msgs/
-  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-  PATTERN "*.h")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,19 +4,19 @@ project(range_msgs)
 find_package(catkin REQUIRED COMPONENTS
 	std_msgs
 	geometry_msgs
-    message_generation
+  message_generation
 )
 
 add_message_files(
-    DIRECTORY msg
-    FILES
-    P2PRange.msg
-    P2PRangeWithPose.msg
+  DIRECTORY msg
+  FILES
+  P2PRange.msg
+  P2PRangeWithPose.msg
 )
 
 generate_messages(DEPENDENCIES
-    std_msgs
-    geometry_msgs
+  std_msgs
+  geometry_msgs
 )
 
 catkin_package(

--- a/package.xml
+++ b/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="2">
   <name>range_msgs</name>
   <version>1.1.1</version>
   <description>
@@ -11,16 +11,17 @@
   <author>Felipe Ramón Fabresse</author>
   <author>Alfredo Vázquez Reyes</author>
   <author>Fernando Caballero Benitez</author>
-  <url></url>
+  <url type="repository">https://github.com/robotics-upo/range_msgs.git</url>
+  <url type="bugtracker">https://github.com/robotics-upo/range_msgs/issues</url>
 
   <buildtool_depend>catkin</buildtool_depend>
-  
-  <build_depend>std_msgs</build_depend>
-  <build_depend>geometry_msgs</build_depend>
+
   <build_depend>message_generation</build_depend>
-  <run_depend>std_msgs</run_depend>
-  <run_depend>geometry_msgs</run_depend>
-  <run_depend>message_runtime</run_depend>
+  <exec_depend>message_runtime</exec_depend>
+  
+  <depend>std_msgs</depend>
+  <depend>geometry_msgs</depend>
+  
 </package>
 
 


### PR DESCRIPTION
We had unnecessary install rules for msg generation, that wanted to use an Include folder that did not exist. This was blocking the release in ROS buildfarm.

I removed this rules and also upgraded the package.xml format to version 2 (recommended).

after you accept the PR, please, update your local clone and repeat the steps to create a new tag:

catkin_generate_changelog --all
git add CHANGELOG.rst
git ci -a -m "changelog"
catkin_prepare_release

Thanks!!
